### PR TITLE
Minor changes to allow working with latest versions of gems

### DIFF
--- a/apnd.gemspec
+++ b/apnd.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
 
   s.executables      = ['apnd']
 
-  s.add_dependency('eventmachine', '= 0.12.10')
-  s.add_dependency('json',         '= 1.4.6')
-  s.add_dependency('daemons',      '= 1.1.0')
+  s.add_dependency('eventmachine', '>= 0.12.10')
+  s.add_dependency('json',         '>= 1.4.6')
+  s.add_dependency('daemons',      '>= 1.1.0')
 
   s.add_development_dependency('shoulda')
 


### PR DESCRIPTION
Changed dependencies to be '>=' instead of '=' since some of the versions are not available any more.
