### PR TITLE
APND Daemon queue persistence using MongoDB & MongoMapper

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -152,6 +152,18 @@ removed your application.
       end
     end
 
+## Persistence
+
+By default, the APND daemon uses an in-memory queue to collect
+notifications until it tries to send them Apple. In the event that the
+daemon crashes, anything in the queue is lost.
+
+You can add persistence, using MongoDB and MongoMapper simply by requiring
+apnd-persistence rather than apnd, e.g.
+
+    require 'apnd-persistence'
+
+Done! See Requirements.
 
 ## Prerequisites
 
@@ -165,6 +177,13 @@ at [developer.apple.com](http://developer.apple.com/).
 * [EventMachine](http://github.com/eventmachine/eventmachine)
 * [Daemons](http://github.com/ghazel/daemons)
 * [JSON](http://github.com/flori/json)
+
+For persistence, you will also need:
+
+* MongoDB
+* MongoMapper
+
+and everything those pull in.
 
 Ruby must be compiled with OpenSSL support.
 

--- a/apnd.gemspec
+++ b/apnd.gemspec
@@ -18,11 +18,20 @@ Gem::Specification.new do |s|
 
   s.executables      = ['apnd']
 
-  s.add_dependency('eventmachine', '= 0.12.10')
+  s.add_dependency('eventmachine', '>= 0.12.10')
   s.add_dependency('json',         '>= 1.4.6')
-  s.add_dependency('daemons',      '= 1.1.0')
+  s.add_dependency('daemons',      '>= 1.1.0')
 
-  s.add_development_dependency('rake', '= 0.8.7')
+  s.add_dependency('mongo', '= 1.3.1')
+  s.add_dependency('bson', '= 1.3.1')
+  s.add_dependency("mongo_mapper", ["= 0.9.1"])
+
+  # Uncomment if you want to use this optimized version of bson that
+  # requires local building
+  #s.add_dependency("bson_ext", ["= 1.3.1"])
+
+  s.add_development_dependency('sdoc', '~> 0.3.11')
+  s.add_development_dependency('rake', '>= 0.8.7')
   s.add_development_dependency('shoulda-context')
   s.add_development_dependency('sdoc-helpers')
   s.add_development_dependency('rdiscount')

--- a/lib/apnd-persistence.rb
+++ b/lib/apnd-persistence.rb
@@ -1,0 +1,3 @@
+require 'apnd'
+require 'apnd/persistence'
+

--- a/lib/apnd/daemon.rb
+++ b/lib/apnd/daemon.rb
@@ -46,6 +46,10 @@ module APND
       end
     end
 
+    def enqueue_notification(n)
+      queue.push(n)
+    end
+
   private
 
     #

--- a/lib/apnd/daemon/protocol.rb
+++ b/lib/apnd/daemon/protocol.rb
@@ -34,7 +34,7 @@ module APND
         chunk = @buffer.slice!(0,json_length + 3 + 32 + 2)
         if notification = APND::Notification.valid?(chunk)
           APND.logger "#{@address.last}:#{@address.first} added new Notification to queue"
-          queue.push(notification)
+          enqueue_notification(notification)
         else
           APND.logger "#{@address.last}:#{@address.first} submitted invalid Notification"
         end
@@ -52,3 +52,4 @@ module APND
     end
   end
 end
+

--- a/lib/apnd/persistence.rb
+++ b/lib/apnd/persistence.rb
@@ -1,0 +1,5 @@
+require 'mongo'
+require 'mongo_mapper'
+require 'apnd/persistence/settings'
+require 'apnd/persistence/daemon'
+require 'apnd/persistence/notification'

--- a/lib/apnd/persistence/daemon.rb
+++ b/lib/apnd/persistence/daemon.rb
@@ -1,0 +1,32 @@
+module APND
+  class Daemon
+    #
+    # Sends each notification in the store upstream to Apple
+    #
+    def process_notifications!
+      pending = APND::Notification.all()
+      if pending.size > 0
+        APND.logger "Queue has #{pending.size} item#{pending.size == 1 ? '' : 's'}"
+        @apple.connect!
+        pending.each do |notification|
+          begin
+            APND.logger "Sending notification for #{notification.token}"
+            @apple.write(notification.to_bytes)
+            notification.destroy
+          rescue Errno::EPIPE, OpenSSL::SSL::SSLError
+            APND.logger "Error, notification will be sent next time around"
+            @apple.reconnect!
+          rescue RuntimeError => error
+            APND.logger "Error: #{error}"
+          end
+        end
+        @apple.disconnect!
+      end
+    end
+
+    def enqueue_notification(n)
+      n.save!
+    end
+
+  end
+end

--- a/lib/apnd/persistence/notification.rb
+++ b/lib/apnd/persistence/notification.rb
@@ -1,0 +1,12 @@
+module APND
+  class Notification
+    include MongoMapper::Document
+        
+    safe
+    timestamps!
+    
+    set_collection_name :apnd_notifications
+
+    key :token
+  end
+end

--- a/lib/apnd/persistence/settings.rb
+++ b/lib/apnd/persistence/settings.rb
@@ -1,0 +1,42 @@
+module APND
+  class Settings
+
+    #
+    # Settings for APND::MongoDB if you want persistence
+    #
+    class MongoDB
+      attr_accessor :host
+      attr_accessor :port
+      attr_accessor :database
+
+      def initialize
+        @host = 'localhost'
+        @port = 27017
+        @database = nil
+      end
+
+      def connect
+        MongoMapper.connection = Mongo::Connection.new(@host, @port)
+        MongoMapper.database = @database
+      end
+    end
+
+    #
+    # Returns the MongoDB settings
+    #
+    def mongodb
+      @mongodb ||= APND::Settings::MongoDB.new
+    end
+
+    #
+    # Mass assign MongoDB settings
+    #
+    def mongodb=(options = {})
+      if options.respond_to?(:keys)
+        mongodb.port = options[:port] if options[:port]
+        mongodb.host = options[:host] if options[:host]
+        mongodb.database = options[:database] if options[:database]
+      end
+    end
+  end
+end

--- a/lib/apnd/version.rb
+++ b/lib/apnd/version.rb
@@ -2,7 +2,7 @@ module APND
   class Version #:nodoc:
     MAJOR = 0
     MINOR = 2
-    TINY  = 1
+    TINY  = 0
 
     def self.to_s
       [MAJOR, MINOR, TINY].join('.')

--- a/lib/apnd/version.rb
+++ b/lib/apnd/version.rb
@@ -2,7 +2,7 @@ module APND
   class Version #:nodoc:
     MAJOR = 0
     MINOR = 2
-    TINY  = 0
+    TINY  = 1
 
     def self.to_s
       [MAJOR, MINOR, TINY].join('.')

--- a/mongo.yml
+++ b/mongo.yml
@@ -1,0 +1,14 @@
+# Turns off slave_ok reads if only_master is true
+# only_master: true
+
+defaults: &defaults
+  host: localhost
+  port: 27017
+  database: database
+
+test:
+  <<: *defaults
+  database: database_test
+
+development:
+  <<: *defaults

--- a/test/apnd_test.rb
+++ b/test/apnd_test.rb
@@ -1,9 +1,8 @@
 require File.dirname(__FILE__) + '/test_helper.rb'
 
 class APNDTest < Test::Unit::TestCase
-  # FIXME: Tests fail if the hash keys here arent in this order. It shouldn't
-  # be so fragile.
-  @@bytes = %|\000\000 \376\025\242}]\363\303Gx\336\373\037O8\200&\\\305,\f\004v\202\";\345\237\266\205\000\251\242\000\\{\"location\":\"New York\",\"aps\":{\"badge\":10,\"sound\":\"default\",\"alert\":\"Red Alert, Numba One!\"}}|
+  # Hash keys must be in this order for tests to pass. A bit fragile...
+  @@bytes = %|\000\000 \376\025\242}]\363\303Gx\336\373\037O8\200&\\\305,\f\004v\202\";\345\237\266\205\000\251\242\000\\{\"aps\":{\"alert\":\"Red Alert, Numba One!\",\"badge\":10,\"sound\":\"default\"},\"location\":\"New York\"}|
 
   context "APND Notification" do
     setup do

--- a/test/persistence_apnd_test.rb
+++ b/test/persistence_apnd_test.rb
@@ -1,0 +1,65 @@
+require File.dirname(__FILE__) + '/test_persistence_helper.rb'
+
+class APNDPersistenceTest < Test::Unit::TestCase
+  @@bytes = %|\000\000 \376\025\242}]\363\303Gx\336\373\037O8\200&\\\305,\f\004v\202\";\345\237\266\205\000\251\242\000\\{\"aps\":{\"alert\":\"Red Alert, Numba One!\",\"badge\":10,\"sound\":\"default\"},\"location\":\"New York\"}|
+
+  context "APND Daemon" do
+    setup do
+      MongoMapper.config = YAML.load(ERB.new(File.read('mongo.yml')).result)
+      @@env = { 'host' => 'localhost', 'port' => 27017}.merge(MongoMapper.config_for_environment('test'))
+
+      APND.configure do |settings|
+        settings.mongodb = 
+          { :host => @@env['host'],
+          :port => @@env['port'],
+          :database => @@env['database']
+        }
+        settings.mongodb.connect
+      end
+    end
+
+    context "Protocol" do
+      setup do
+        @daemon = TestPersistenceDaemon.new
+        MongoMapper.database.collections.each(&:remove)
+      end
+
+      should "add valid notification to queue" do
+        @daemon.receive_data(@@bytes)
+        @daemon.unbind
+        assert_equal 1, APND::Notification.all.count
+      end
+
+      should "receive multiple Notifications in a single packet" do
+        @daemon.receive_data([@@bytes, @@bytes, @@bytes].join("\n"))
+        @daemon.unbind
+        assert_equal 3, APND::Notification.all.count
+      end
+
+      should "raise InvalidNotificationHeader parsing a bad packet" do
+        assert_raise APND::Errors::InvalidNotificationHeader do
+          APND::Notification.parse("I'm not a packet!")
+        end
+        assert_equal 0, APND::Notification.all.count
+      end
+
+      context "newlines" do
+        should "be able to parse a notification with an embedded newline character" do
+          @newline_notification = APND::Notification.new({
+            # :token  => 'fe15a27d5df3c34778defb1f4f3880265cc52c0c047682223be59fb68500a9a2',
+            :token  => '74b2a2197d7727a70f939de05a4c7fe8bd4a7d960a77ef4701a80cb7b293ee23',
+            :alert  => 'Red Alert, Numba One!',
+            :sound  => 'default',
+            :badge  => 10,
+            :custom => { 'location' => 'New York' }
+          })
+          @daemon.receive_data(@newline_notification.to_bytes)
+          @daemon.unbind
+          assert_equal 1, APND::Notification.all.count
+        end
+      end
+
+    end
+  end
+
+end

--- a/test/test_persistence_helper.rb
+++ b/test/test_persistence_helper.rb
@@ -7,9 +7,9 @@ begin
 rescue LoadError
 end
 
-require 'apnd'
+require 'apnd-persistence'
 
-class TestDaemon
+class TestPersistenceDaemon < APND::Daemon
   include APND::Daemon::Protocol
 
   def initialize
@@ -19,10 +19,6 @@ class TestDaemon
 
   def queue
     @queue
-  end
-
-  def enqueue_notification(n)
-    queue.push(n)
   end
 
 end


### PR DESCRIPTION
For our purposes, we needed the APND Daemon queue to be persistent between the time a notification is accepted by the daemon and the time the deamon wakes up to send it.

I added support for persistence using MongoDB and MongoMapper. It's optionally enabled simply by requiring apnd-persistence.rb rather than apnd.rb.

Please consider adding these changes (in some form) to your master branch.

Thanks for writing this gem. It's a nice solution!
